### PR TITLE
Fix Remote Help installation script download logic

### DIFF
--- a/scripts/intune/scr-app-102-install-remote-help.sh
+++ b/scripts/intune/scr-app-102-install-remote-help.sh
@@ -181,12 +181,10 @@ downloadApp () {
     echo "$(date) | Downloading $appname [$weburl]"
 
     cd "$tempdir"
-    curl -f -s --connect-timeout 30 --retry 5 --retry-delay 60 --compressed -L -J -O "$weburl"
+    tempfile="$appname.pkg"
+    curl -f -s --connect-timeout 30 --retry 5 --retry-delay 60 --compressed -L -o "$tempfile" "$weburl"
     if [[ $? == 0 ]]; then
-        for f in *; do
-            tempfile=$f
-            echo "$(date) | Found downloaded tempfile [$tempfile]"
-        done
+        echo "$(date) | Downloaded to [$tempfile]"
         case $tempfile in
             *.pkg|*.PKG|*.mpkg|*.MPKG)
                 packageType="PKG"


### PR DESCRIPTION
## Summary
- Update download URL to correct macOS endpoint (`https://aka.ms/downloadremotehelpmacos`)
- Fix curl command to explicitly name output file with `.pkg` extension

Fixes #7

## Problem
The script failed with "Expected a PKG, but downloaded an unsupported type" because:
1. The `aka.ms` redirect doesn't provide a `Content-Disposition` header
2. curl's `-J` flag couldn't determine the filename, falling back to URL path (`downloadremotehelpmacos`)
3. The file lacked a `.pkg` extension, failing validation

## Solution
Replace `-J -O` with `-o "$appname.pkg"` to explicitly control the output filename regardless of server headers.

## Test plan
- [x] Run script on macOS device
- [x] Verify PKG downloads and installs successfully