### PR TITLE
Fix legacy manifest format and add enrollment restriction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ brew install --cask powershell
 winget install Microsoft.PowerShell
 ```
 
-> PowerShell modules (Microsoft Graph) are installed on demand the first time you run the script.
+> PowerShell modules (Microsoft Graph SDK) are installed automatically the first time you run the script — no manual `Install-Module` required.
 
 ### 2. Prepare your tenant.
 - **MDM Authority:** determines how you manage your devices (cannot be none). [Learn how](https://learn.microsoft.com/en-us/intune/intune-service/fundamentals/mdm-authority-set).
 - **APNS certificate:** Required for any macOS enrollment. [Learn how](https://learn.microsoft.com/mem/intune/enrollment/apple-mdm-push-certificate-get).
-- **Permissions:** Use an Intune Administrator (or equivalent) or grant `DeviceManagementConfiguration.ReadWrite.All`, `DeviceManagementApps.ReadWrite.All`, `DeviceManagementManagedDevices.ReadWrite.All`, `DeviceManagementScripts.ReadWrite.All`, `Group.Read.All`.
+- **Permissions:** Use an Intune Administrator (or equivalent) or grant `DeviceManagementConfiguration.ReadWrite.All`, `DeviceManagementApps.ReadWrite.All`, `DeviceManagementManagedDevices.ReadWrite.All`, `DeviceManagementScripts.ReadWrite.All`, `DeviceManagementServiceConfig.ReadWrite.All`, `Group.Read.All`.
 - **Optional MDE:** Download your org-specific onboarding file before using `--mde` (see [`mde/README.md`](mde/README.md) for detailed steps).
 
 ### 3. Clone and run
@@ -47,7 +47,7 @@ pwsh ./mainScript.ps1 --assign-group "Intune Mac Pilot" --apply
 ### 4. Common flags
 | Flag | Purpose |
 |------|---------|
-| `--apps`, `--config`, `--compliance`, `--scripts`, `--custom-attributes` | Limit the import scope to specific artifact types |
+| `--apps`, `--config`, `--compliance`, `--scripts`, `--custom-attributes`, `--enrollment` | Limit the import scope to specific artifact types |
 | `--assign-group "Name"` | Assign every created object to an Entra group |
 | `--prefix "[custom]"` | Override the default naming prefix |
 | `--mde` | Include the `mde/` content (requires onboarding file) |
@@ -75,6 +75,7 @@ For the full artifact catalog and settings, see `INTUNE-MY-MACS-DOCUMENTATION.md
 ---
 
 ## Troubleshooting at a glance
+- **`Connect-MgGraph` not recognized:** The Microsoft Graph SDK installs automatically on first run. If it fails, install manually: `Install-Module Microsoft.Graph.Authentication -Scope CurrentUser`.
 - **Auth or permission errors:** Re-run `pwsh ./mainScript.ps1` after confirming the Graph permissions above; modules auto-install per user.
 - **Devices not receiving policies:** Verify APNS, device enrollment, and group membership, then force a device sync.
 

--- a/configurations/intune/pol-sec-002-firewall.xml
+++ b/configurations/intune/pol-sec-002-firewall.xml
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest>
-    <file>FirewallConfiguration.json</file>
-    <type>configuration-policy</type>
-    <name>Firewall Configuration</name>
-    <description>Enables macOS firewall and prevents users from accessing and modifying firewall settings through System Preferences, ensuring firewall configuration remains under IT control.</description>
-    <priority>20</priority>
-    <supersedes>FirewallUIRestriction.json</supersedes>
-    <notes>This policy combines firewall enablement with UI restrictions to provide comprehensive firewall management. It supersedes the standalone FirewallUIRestriction policy.</notes>
-</manifest>
+<MacIntuneManifest>
+  <ReferenceId>POL-SEC-002</ReferenceId>
+  <Version>1.0</Version>
+	<Type>Policy</Type>
+	<Name>POL-SEC-002 - Firewall</Name>
+	<Description>Enables macOS firewall and prevents users from accessing and modifying firewall settings through System Preferences, ensuring firewall configuration remains under IT control.</Description>
+	<Platform>macOS</Platform>
+	<Category>Security</Category>
+	<SourceFile>configurations/intune/pol-sec-002-firewall.json</SourceFile>
+	<SettingsCount>2</SettingsCount>
+</MacIntuneManifest>

--- a/configurations/intune/pol-sec-004-guest-account.json
+++ b/configurations/intune/pol-sec-004-guest-account.json
@@ -23,7 +23,7 @@
       "id": "0",
       "settingInstance": {
         "@odata.type": "#microsoft.graph.deviceManagementConfigurationGroupSettingCollectionInstance",
-        "settingDefinitionId": "com.apple.mcx_com.apple.mcx",
+        "settingDefinitionId": "com.apple.mcx_com.apple.mcx-accounts",
         "settingInstanceTemplateReference": null,
         "groupSettingCollectionValue": [
           {
@@ -31,11 +31,11 @@
             "children": [
               {
                 "@odata.type": "#microsoft.graph.deviceManagementConfigurationChoiceSettingInstance",
-                "settingDefinitionId": "com.apple.mcx_DisableGuestAccount",
+                "settingDefinitionId": "com.apple.mcx_disableguestaccount",
                 "settingInstanceTemplateReference": null,
                 "choiceSettingValue": {
                   "settingValueTemplateReference": null,
-                  "value": "com.apple.mcx_DisableGuestAccount_true",
+                  "value": "com.apple.mcx_disableguestaccount_true",
                   "children": []
                 }
               }

--- a/configurations/intune/pol-sec-004-guest-account.xml
+++ b/configurations/intune/pol-sec-004-guest-account.xml
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest>
-    <file>GuestAccountSecurityConfiguration.json</file>
-    <type>configuration-policy</type>
-    <name>Guest Account Security Configuration</name>
-    <description>Disables guest account access to enhance security on managed macOS devices. Guest accounts can bypass security policies and provide unauthorized access to the system, making this configuration essential for enterprise security.</description>
-    <priority>10</priority>
-    <notes>
-        Setting configured:
-        - DisableGuestAccount: true (prevents guest account login)
-        
-        This addresses the Mac Evaluation Utility warning about unmanaged guest account settings by explicitly disabling guest account access, which is a security best practice for managed devices.
-    </notes>
-</manifest>
+<MacIntuneManifest>
+  <ReferenceId>POL-SEC-004</ReferenceId>
+  <Version>1.0</Version>
+	<Type>Policy</Type>
+	<Name>POL-SEC-004 - Guest Account Security</Name>
+	<Description>Disables guest account access to enhance security on managed macOS devices. Guest accounts can bypass security policies and provide unauthorized access to the system, making this configuration essential for enterprise security.</Description>
+	<Platform>macOS</Platform>
+	<Category>Security</Category>
+	<SourceFile>configurations/intune/pol-sec-004-guest-account.json</SourceFile>
+	<SettingsCount>1</SettingsCount>
+</MacIntuneManifest>

--- a/configurations/intune/pol-sys-101-login-items.xml
+++ b/configurations/intune/pol-sys-101-login-items.xml
@@ -1,15 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest>
-    <file>Managed Login Items.json</file>
-    <type>configuration-policy</type>
-    <name>Managed Login Items</name>
-    <description>Configures approved login items and background processes for macOS devices. Allows specific applications (Palo Alto and Microsoft) to run background services by whitelisting their team identifiers, ensuring only trusted applications can automatically start at login.</description>
-    <priority>25</priority>
-    <notes>
-        Approved team identifiers:
-        - PXPZ95SK77 (Palo Alto Networks)
-        - UBF8T346G9 (Microsoft Corporation)
-        
-        This policy helps maintain security by preventing unauthorized applications from running background processes while allowing approved enterprise applications to function properly.
-    </notes>
-</manifest>
+<MacIntuneManifest>
+  <ReferenceId>POL-SYS-101</ReferenceId>
+  <Version>1.0</Version>
+	<Type>Policy</Type>
+	<Name>POL-SYS-101 - Managed Login Items</Name>
+	<Description>Configures approved login items and background processes for macOS devices. Allows specific applications (Palo Alto and Microsoft) to run background services by whitelisting their team identifiers, ensuring only trusted applications can automatically start at login.</Description>
+	<Platform>macOS</Platform>
+	<Category>System Configuration</Category>
+	<SourceFile>configurations/intune/pol-sys-101-login-items.json</SourceFile>
+	<SettingsCount>1</SettingsCount>
+</MacIntuneManifest>

--- a/configurations/intune/pol-sys-105-enrollment-restriction.json
+++ b/configurations/intune/pol-sys-105-enrollment-restriction.json
@@ -1,13 +1,10 @@
 {
-  "@odata.type": "#microsoft.graph.deviceEnrollmentPlatformRestriction",
+  "@odata.type": "#microsoft.graph.deviceEnrollmentPlatformRestrictionConfiguration",
   "displayName": "macOS Enrollment Restriction",
   "description": "Controls macOS device enrollment settings and restrictions for managed devices.",
+  "platformType": "mac",
   "platformRestriction": {
     "platformBlocked": false,
-    "personalDeviceEnrollmentBlocked": false,
-    "osMinimumVersion": "15.0",
-    "osMaximumVersion": null,
-    "blockedManufacturers": [],
-    "blockedSkus": []
+    "personalDeviceEnrollmentBlocked": false
   }
 }

--- a/configurations/intune/pol-sys-105-enrollment-restriction.xml
+++ b/configurations/intune/pol-sys-105-enrollment-restriction.xml
@@ -1,9 +1,11 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<manifest>
-    <file>macos-enrollment-restriction.json</file>
-    <type>enrollment-restriction</type>
-    <name>macOS Enrollment Restriction</name>
-    <description>Controls macOS device enrollment settings and restrictions for managed devices. Sets minimum OS version requirement to macOS 15.0 and allows both corporate and personal device enrollment.</description>
-    <priority>5</priority>
-    <notes>Configures basic enrollment restrictions for macOS devices, ensuring only supported OS versions can enroll while maintaining flexibility for different device ownership types.</notes>
-</manifest>
+<MacIntuneManifest>
+  <ReferenceId>POL-SYS-105</ReferenceId>
+  <Version>1.0</Version>
+	<Type>EnrollmentRestriction</Type>
+	<Name>POL-SYS-105 - macOS Enrollment Restriction</Name>
+	<Description>Controls macOS device enrollment settings and restrictions for managed devices. Allows both corporate and personal device enrollment. Use compliance policies for minimum OS version enforcement.</Description>
+	<Platform>macOS</Platform>
+	<Category>System Configuration</Category>
+	<SourceFile>configurations/intune/pol-sys-105-enrollment-restriction.json</SourceFile>
+	<SettingsCount>1</SettingsCount>
+</MacIntuneManifest>

--- a/mainScript.ps1
+++ b/mainScript.ps1
@@ -21,6 +21,7 @@ $importPackages             = $true
 $importScripts              = $true
 $importCompliance           = $true  # new: compliance policies
 $importCustomAttrs          = $true  # new: custom attributes
+$importEnrollmentRestrictions = $true  # enrollment platform restrictions
 $includeMde                 = $false # include mde/ folder content only if --mde specified
 $applyChanges               = $false # require --apply to move beyond dry-run mode
 
@@ -31,6 +32,7 @@ $createdComplianceIds = @()
 $createdScriptIds = @()
 $createdAppIds = @()
 $createdCustomAttrIds = @()  # custom attributes
+$createdEnrollmentRestrictionIds = @()  # enrollment restrictions
 
 # set policy prefix (spacing appended automatically later)
 $policyPrefix = "[intune-my-macs]"
@@ -99,6 +101,7 @@ function Get-DistributedManifests {
 
     switch ($type) {
             'Policy' { $obj | Add-Member -NotePropertyName settingCount -NotePropertyValue $settingsCount -Force }
+            'EnrollmentRestriction' { $obj | Add-Member -NotePropertyName settingCount -NotePropertyValue $settingsCount -Force }
             'Script' {
         $scriptNode = $xmlRoot.Element('Script')
                 if ($scriptNode) {
@@ -185,6 +188,15 @@ function Test-DistributedManifest {
                     if (-not (Test-Path -LiteralPath $full)) { Write-Warning ("CustomConfig file missing: {0}" -f $item.filePath) }
                 }
             }
+            'EnrollmentRestriction' {
+                foreach ($req in 'name','filePath') {
+                    if (-not $item.$req) { Write-Host ("EnrollmentRestriction missing {0}: {1}" -f $req, $item.name) -ForegroundColor Red; $errors++ }
+                }
+                if ($item.filePath) {
+                    $full = Join-Path $repoRoot $item.filePath
+                    if (-not (Test-Path -LiteralPath $full)) { Write-Warning ("EnrollmentRestriction file missing: {0}" -f $item.filePath) }
+                }
+            }
         }
     }
     if ($errors -gt 0) { Write-Host "Validation completed with $errors issue(s)." -ForegroundColor Yellow } else { Write-Host "Validation passed with no issues." -ForegroundColor Green }
@@ -258,7 +270,8 @@ if ($argsLower -contains '-h' -or $argsLower -contains '--help') {
     Write-Host "  --config              Import only configuration policies"
     Write-Host "  --compliance          Import only compliance policies"
     Write-Host "  --scripts             Import only shell scripts"
-    Write-Host "  --custom-attributes   Import only custom attributes`n"
+    Write-Host "  --custom-attributes   Import only custom attributes"
+    Write-Host "  --enrollment          Import only enrollment restrictions`n"
     Write-Host "OPTIONAL FEATURES:" -ForegroundColor Yellow
     Write-Host "  --mde                 Include Microsoft Defender for Endpoint (mde/) folder content"
     Write-Host "  --show-all-scripts    Show all scripts during enumeration`n"
@@ -289,7 +302,7 @@ if ($argsLower -contains '-h' -or $argsLower -contains '--help') {
 }
 
 if ($args.Count -gt 0) {
-    $knownFlags = @('--apps','--config','--compliance','--scripts','--custom-attributes','--show-all-scripts','--remove-all','--mde','-mde','--apply','--prefix','--assign-group','--tenant-id','-h','--help')
+    $knownFlags = @('--apps','--config','--compliance','--scripts','--custom-attributes','--enrollment','--show-all-scripts','--remove-all','--mde','-mde','--apply','--prefix','--assign-group','--tenant-id','-h','--help')
     $valueFlags = @('--prefix','--assign-group','--tenant-id')
     $unknownArgs = @(); $missingValueArgs = @()
     $idx = 0
@@ -330,12 +343,13 @@ if ($args.Count -gt 0) {
 }
 
 if ($argsLower.Count -gt 0) {
-    $importPolicies = $false; $importPackages = $false; $importScripts = $false; $importCompliance = $false; $importCustomAttrs = $false
+    $importPolicies = $false; $importPackages = $false; $importScripts = $false; $importCompliance = $false; $importCustomAttrs = $false; $importEnrollmentRestrictions = $false
     if ($argsLower -contains '--apps') { $importPackages = $true }
     if ($argsLower -contains '--config') { $importPolicies = $true }
     if ($argsLower -contains '--compliance') { $importCompliance = $true }
     if ($argsLower -contains '--scripts' ) { $importScripts = $true }
     if ($argsLower -contains '--custom-attributes') { $importCustomAttrs = $true }
+    if ($argsLower -contains '--enrollment') { $importEnrollmentRestrictions = $true }
     $showAllScripts = $false
     if ($argsLower -contains '--show-all-scripts') { $showAllScripts = $true }
     if ($argsLower -contains '--remove-all') { $removeAll = $true }
@@ -381,12 +395,12 @@ if ($argsLower.Count -gt 0) {
             $tenantId = $value.Trim('"')
         }
     }
-    if (-not ($importPolicies -or $importPackages -or $importScripts -or $importCompliance -or $importCustomAttrs)) {
-    Write-Warning "No valid selector provided (--apps, --config, --scripts, --custom-attributes). Defaulting to all."
-        $importPolicies = $true; $importPackages = $true; $importScripts = $true; $importCompliance = $true; $importCustomAttrs = $true
+    if (-not ($importPolicies -or $importPackages -or $importScripts -or $importCompliance -or $importCustomAttrs -or $importEnrollmentRestrictions)) {
+    Write-Warning "No valid selector provided (--apps, --config, --scripts, --custom-attributes, --enrollment). Defaulting to all."
+        $importPolicies = $true; $importPackages = $true; $importScripts = $true; $importCompliance = $true; $importCustomAttrs = $true; $importEnrollmentRestrictions = $true
         $showAllScripts = $true
     } else {
-        Write-Host ("Selection: configPolicies={0} compliance={1} packages={2} scripts={3} customAttributes={4} showAllScripts={5} includeMde={6}" -f $importPolicies, $importCompliance, $importPackages, $importScripts, $importCustomAttrs, $showAllScripts, $includeMde) -ForegroundColor Cyan
+        Write-Host ("Selection: configPolicies={0} compliance={1} packages={2} scripts={3} customAttributes={4} enrollmentRestrictions={5} showAllScripts={6} includeMde={7}" -f $importPolicies, $importCompliance, $importPackages, $importScripts, $importCustomAttrs, $importEnrollmentRestrictions, $showAllScripts, $includeMde) -ForegroundColor Cyan
     }
 }
 
@@ -401,8 +415,29 @@ if ($applyChanges) {
 }
 
 # Connect to Microsoft Graph (add apps scope + groups for assignments + scripts for shell scripts)
+# Ensure Microsoft.Graph.Authentication module is available
+if (-not (Get-Module -ListAvailable -Name Microsoft.Graph.Authentication)) {
+    Write-Host "Microsoft Graph PowerShell SDK not found. Installing..." -ForegroundColor Yellow
+    try {
+        Install-Module Microsoft.Graph.Authentication -Scope CurrentUser -Force -AllowClobber -ErrorAction Stop
+        Write-Host "Microsoft.Graph.Authentication installed successfully." -ForegroundColor Green
+    } catch {
+        Write-Host "`nERROR: Failed to install Microsoft.Graph.Authentication module." -ForegroundColor Red
+        Write-Host "Install it manually with:  Install-Module Microsoft.Graph.Authentication -Scope CurrentUser" -ForegroundColor Yellow
+        Write-Host "For details see: https://learn.microsoft.com/powershell/microsoftgraph/installation`n" -ForegroundColor Cyan
+        exit 1
+    }
+}
+try {
+    Import-Module Microsoft.Graph.Authentication -ErrorAction Stop
+} catch {
+    Write-Host "`nERROR: Failed to load Microsoft.Graph.Authentication module." -ForegroundColor Red
+    Write-Host "Try reinstalling:  Install-Module Microsoft.Graph.Authentication -Scope CurrentUser -Force" -ForegroundColor Yellow
+    exit 1
+}
+
 $graphParams = @{
-    Scopes = "DeviceManagementConfiguration.ReadWrite.All,DeviceManagementApps.ReadWrite.All,DeviceManagementManagedDevices.ReadWrite.All,DeviceManagementScripts.ReadWrite.All,Group.Read.All"
+    Scopes = "DeviceManagementConfiguration.ReadWrite.All,DeviceManagementApps.ReadWrite.All,DeviceManagementManagedDevices.ReadWrite.All,DeviceManagementScripts.ReadWrite.All,DeviceManagementServiceConfig.ReadWrite.All,Group.Read.All"
     NoWelcome = $true
 }
 if ($tenantId) {
@@ -430,14 +465,15 @@ function Remove-IntunePrefixedContent {
         [bool]$ApplyChanges = $false
     )
     if (-not $Prefix) { Write-Error "Prefix is empty; refusing to continue."; return }
-    Write-Host "Scanning Intune for policies, custom configs (mobileconfig), compliance policies, scripts, custom attributes, and apps beginning with prefix: '$Prefix'" -ForegroundColor Cyan
+    Write-Host "Scanning Intune for policies, custom configs (mobileconfig), compliance policies, enrollment restrictions, scripts, custom attributes, and apps beginning with prefix: '$Prefix'" -ForegroundColor Cyan
 
     # Build OData filter string for macOS custom configuration deviceConfiguration lookup
     $escapedFilterDeviceConfigs  = [System.Uri]::EscapeDataString("startsWith(displayName,'$Prefix')")
 
-    $policies = @(); $customConfigs = @(); $compliancePolicies = @(); $scripts = @(); $customAttrs = @(); $apps = @()
+    $policies = @(); $customConfigs = @(); $compliancePolicies = @(); $enrollmentRestrictions = @(); $scripts = @(); $customAttrs = @(); $apps = @()
     
     # Configuration Policies - always use client-side filtering for reliability with special characters
+    Write-Host "  Scanning configuration policies..." -ForegroundColor DarkGray -NoNewline
     try {
         $allPolicies = @()
         $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceManagement/configurationPolicies?`$select=id,name"
@@ -454,10 +490,13 @@ function Remove-IntunePrefixedContent {
             $policies = $allPolicies | Where-Object { $_.name -and $_.name.StartsWith($Prefix) }
             if ($env:IMM_DEBUG -eq '1') { Write-Host "DEBUG: Client-side filter matched $($policies.Count) policies with prefix '$Prefix'" -ForegroundColor DarkCyan }
         }
+        Write-Host " done ($($allPolicies.Count) found)" -ForegroundColor DarkGray
     } catch {
+        Write-Host " failed" -ForegroundColor Red
         Write-Warning "Failed to query configuration policies: $($_.Exception.Message)"
     }
     # Compliance Policies - use client-side filtering with pagination
+    Write-Host "  Scanning compliance policies..." -ForegroundColor DarkGray -NoNewline
     try {
         $allCompliance = @()
         $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicies?`$select=id,displayName"
@@ -469,10 +508,13 @@ function Remove-IntunePrefixedContent {
         if ($allCompliance) {
             $compliancePolicies = $allCompliance | Where-Object { $_.displayName -and $_.displayName.StartsWith($Prefix) }
         }
+        Write-Host " done ($($allCompliance.Count) found)" -ForegroundColor DarkGray
     } catch {
+        Write-Host " failed" -ForegroundColor Red
         Write-Warning "Failed to query compliance policies: $($_.Exception.Message)"
     }
     # macOS custom configuration (mobileconfig) live under deviceConfigurations with type macOSCustomConfiguration
+    Write-Host "  Scanning custom configs (mobileconfig)..." -ForegroundColor DarkGray -NoNewline
     try {
         $dcUrl = "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations?`$filter=$escapedFilterDeviceConfigs"
         $raw = @()
@@ -486,7 +528,9 @@ function Remove-IntunePrefixedContent {
             # Some responses may omit @odata.type if not selected; also detect via payload-related properties
             $customConfigs = $raw | Where-Object { ($_.displayName -and $_.displayName.StartsWith($Prefix)) -and ( $_.'@odata.type' -eq '#microsoft.graph.macOSCustomConfiguration' -or $_.PSObject.Properties.Name -contains 'payload' -or $_.PSObject.Properties.Name -contains 'payloadName') }
         }
+        Write-Host " done" -ForegroundColor DarkGray
     } catch {
+        Write-Host " failed" -ForegroundColor Red
         Write-Warning "Primary query for custom configs failed: $($_.Exception.Message) - attempting broad fallback"
         try {
             $raw = @(); $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations"
@@ -497,6 +541,7 @@ function Remove-IntunePrefixedContent {
     }
     
     # Scripts - use client-side filtering with pagination
+    Write-Host "  Scanning scripts..." -ForegroundColor DarkGray -NoNewline
     try {
         $allScripts = @()
         $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceShellScripts?`$select=id,displayName"
@@ -506,9 +551,14 @@ function Remove-IntunePrefixedContent {
             $allScripts += $resp.value
         }
         if ($allScripts) { $scripts = $allScripts | Where-Object { $_.displayName -and $_.displayName.StartsWith($Prefix) } }
-    } catch { Write-Warning "Failed to query scripts: $($_.Exception.Message)" }
+        Write-Host " done ($($allScripts.Count) found)" -ForegroundColor DarkGray
+    } catch {
+        Write-Host " failed" -ForegroundColor Red
+        Write-Warning "Failed to query scripts: $($_.Exception.Message)"
+    }
     
     # Custom Attributes - use client-side filtering with pagination
+    Write-Host "  Scanning custom attributes..." -ForegroundColor DarkGray -NoNewline
     try {
         $allCustomAttrs = @()
         $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceCustomAttributeShellScripts?`$select=id,displayName"
@@ -518,9 +568,31 @@ function Remove-IntunePrefixedContent {
             $allCustomAttrs += $resp.value
         }
         if ($allCustomAttrs) { $customAttrs = $allCustomAttrs | Where-Object { $_.displayName -and $_.displayName.StartsWith($Prefix) } }
-    } catch { Write-Warning "Failed to query custom attributes: $($_.Exception.Message)" }
+        Write-Host " done ($($allCustomAttrs.Count) found)" -ForegroundColor DarkGray
+    } catch {
+        Write-Host " failed" -ForegroundColor Red
+        Write-Warning "Failed to query custom attributes: $($_.Exception.Message)"
+    }
+    
+    # Enrollment Restrictions - use client-side filtering with pagination
+    Write-Host "  Scanning enrollment restrictions..." -ForegroundColor DarkGray -NoNewline
+    try {
+        $allEnrollRestrictions = @()
+        $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations?`$select=id,displayName"
+        $allEnrollRestrictions += $resp.value
+        while ($resp.'@odata.nextLink') {
+            $resp = Invoke-MgGraphRequest -Method GET -Uri $resp.'@odata.nextLink'
+            $allEnrollRestrictions += $resp.value
+        }
+        if ($allEnrollRestrictions) { $enrollmentRestrictions = $allEnrollRestrictions | Where-Object { $_.displayName -and $_.displayName.StartsWith($Prefix) } }
+        Write-Host " done ($($allEnrollRestrictions.Count) found)" -ForegroundColor DarkGray
+    } catch {
+        Write-Host " failed" -ForegroundColor Red
+        Write-Warning "Failed to query enrollment restrictions: $($_.Exception.Message)"
+    }
     
     # Apps - use client-side filtering with pagination
+    Write-Host "  Scanning apps..." -ForegroundColor DarkGray -NoNewline
     try {
         $allApps = @()
         $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps?`$select=id,displayName"
@@ -530,15 +602,20 @@ function Remove-IntunePrefixedContent {
             $allApps += $resp.value
         }
         if ($allApps) { $apps = $allApps | Where-Object { $_.displayName -and $_.displayName.StartsWith($Prefix) } }
-    } catch { Write-Warning "Failed to query apps: $($_.Exception.Message)" }
+        Write-Host " done ($($allApps.Count) found)" -ForegroundColor DarkGray
+    } catch {
+        Write-Host " failed" -ForegroundColor Red
+        Write-Warning "Failed to query apps: $($_.Exception.Message)"
+    }
 
     $pCount = ($policies | Measure-Object).Count
     $xCount = ($customConfigs | Measure-Object).Count
     $cCount = ($compliancePolicies | Measure-Object).Count
+    $eCount = ($enrollmentRestrictions | Measure-Object).Count
     $sCount = ($scripts  | Measure-Object).Count
     $caCount = ($customAttrs | Measure-Object).Count
     $aCount = ($apps     | Measure-Object).Count
-    if (($pCount + $xCount + $cCount + $sCount + $caCount + $aCount) -eq 0) {
+    if (($pCount + $xCount + $cCount + $eCount + $sCount + $caCount + $aCount) -eq 0) {
         Write-Host "No Intune objects found with prefix '$Prefix'. Nothing to remove." -ForegroundColor Yellow
         return
     }
@@ -564,12 +641,16 @@ function Remove-IntunePrefixedContent {
         Write-Host "Custom Attributes ($caCount):" -ForegroundColor Magenta
         $customAttrs | ForEach-Object { Write-Host "  • $($_.displayName)  [$($_.id)]" }
     }
+    if ($eCount -gt 0) {
+        Write-Host "Enrollment Restrictions ($eCount):" -ForegroundColor Magenta
+        $enrollmentRestrictions | ForEach-Object { Write-Host "  • $($_.displayName)  [$($_.id)]" }
+    }
     if ($aCount -gt 0) {
         Write-Host "Apps ($aCount):" -ForegroundColor Magenta
         $apps | ForEach-Object { Write-Host "  • $($_.displayName)  [$($_.id)]" }
     }
 
-    Write-Host "Summary: $pCount config policies, $xCount custom configs, $cCount compliance policies, $sCount scripts, $caCount custom attributes, $aCount apps will be permanently removed." -ForegroundColor Cyan
+    Write-Host "Summary: $pCount config policies, $xCount custom configs, $cCount compliance policies, $eCount enrollment restrictions, $sCount scripts, $caCount custom attributes, $aCount apps will be permanently removed." -ForegroundColor Cyan
 
     if (-not $ApplyChanges) {
         Write-Host "[dry-run] Skipping deletion because --apply was not provided." -ForegroundColor Yellow
@@ -617,6 +698,12 @@ function Remove-IntunePrefixedContent {
             Invoke-MgGraphRequest -Method DELETE -Uri "https://graph.microsoft.com/beta/deviceAppManagement/mobileApps/$($a.id)" | Out-Null
             Write-Host "Deleted app: $($a.displayName)" -ForegroundColor Green
         } catch { Write-Warning "Failed to delete app $($a.displayName): $($_.Exception.Message)" }
+    }
+    foreach ($er in $enrollmentRestrictions) {
+        try {
+            Invoke-MgGraphRequest -Method DELETE -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations/$($er.id)" | Out-Null
+            Write-Host "Deleted enrollment restriction: $($er.displayName)" -ForegroundColor Green
+        } catch { Write-Warning "Failed to delete enrollment restriction $($er.displayName): $($_.Exception.Message)" }
     }
     Write-Host "Deletion complete." -ForegroundColor Cyan
 }
@@ -1422,6 +1509,45 @@ if ($importCustomAttrs) {
     }
 }
 
+# Enumerate enrollment restrictions
+if ($importEnrollmentRestrictions) {
+    $createdEnrollmentRestrictionIds = @()
+    $enrollmentRestrictions = @()
+    if ($distributedItems) { $enrollmentRestrictions = $distributedItems | Where-Object { $_.type -eq 'EnrollmentRestriction' } }
+    Write-Host "Found $($enrollmentRestrictions.Count) enrollment restriction(s):`n" -ForegroundColor Cyan
+    foreach ($er in $enrollmentRestrictions) {
+        $erPath = Join-Path $repoRoot $er.filePath
+        $exists = Test-Path -LiteralPath $erPath
+        $status = if ($exists) { 'OK' } else { 'MISSING' }
+        $desc = $er.description
+        if ($null -ne $desc -and $desc.Length -gt 140) { $desc = $desc.Substring(0,137)+'...' }
+        Write-Host "• $($er.name)" -ForegroundColor Yellow
+        Write-Host "  - Category: $($er.category); Platform: $($er.platform)"
+        Write-Host "  - Path: $($er.filePath) [$status]"
+        if ($desc) { Write-Host "  - Desc: $desc" }
+        if (-not $exists) { Write-Host "  - Enrollment restriction JSON missing, skipping." -ForegroundColor Red; Write-Host ''; continue }
+        try {
+            $json = Get-Content -LiteralPath $erPath -Raw | ConvertFrom-Json -Depth 15
+            $json.displayName = $policyPrefix + $er.name
+            $body = $json | ConvertTo-Json -Depth 20
+            if (-not $applyChanges) {
+                Write-Host "  - [dry-run] Would create enrollment restriction '$($json.displayName)'." -ForegroundColor DarkGray
+            } else {
+                $resp = Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations" -Body $body
+                if ($resp -and $resp.id) {
+                    Write-Host "  - Enrollment restriction imported with ID: $($resp.id)" -ForegroundColor Green
+                    $createdEnrollmentRestrictionIds += $resp.id
+                } else {
+                    Write-Warning "  - Import returned no ID"
+                }
+            }
+        } catch {
+            Write-Error "Failed to import enrollment restriction '$($er.name)': $_"
+        }
+        Write-Host ""
+    }
+}
+
 # Enumerate packages/apps
 if ($importPackages) {
     $createdAppIds = @()
@@ -1652,6 +1778,19 @@ if ($assignGroupName) {
             }
         } else {
             Write-Host "Skipping app assignments (no packages imported)." -ForegroundColor DarkGray
+        }
+
+        # Assign Enrollment Restrictions only if imported this run
+        if ($importEnrollmentRestrictions -and $createdEnrollmentRestrictionIds.Count -gt 0) {
+            foreach ($erId in ($createdEnrollmentRestrictionIds | Sort-Object -Unique)) {
+                try {
+                    $assignBody = @{ enrollmentConfigurationAssignments = @(@{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $groupId } }) } | ConvertTo-Json -Depth 6
+                    Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations/$erId/assign" -Body $assignBody | Out-Null
+                    Write-Host "Assigned enrollment restriction $erId to group" -ForegroundColor Green
+                } catch { Write-Warning "Failed to assign enrollment restriction ${erId}: $($_.Exception.Message)" }
+            }
+        } else {
+            Write-Host "Skipping enrollment restriction assignments (none imported)." -ForegroundColor DarkGray
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #11 — Four XML manifests using the legacy `<manifest>` root element were silently skipped by `mainScript.ps1`'s `<MacIntuneManifest>` filter.

## Changes

### XML Manifests migrated to `<MacIntuneManifest>` format
- `pol-sec-002-firewall.xml` (POL-SEC-002)
- `pol-sec-004-guest-account.xml` (POL-SEC-004)
- `pol-sys-101-login-items.xml` (POL-SYS-101)
- `pol-sys-105-enrollment-restriction.xml` (POL-SYS-105)

### JSON payload fixes
- **pol-sec-004-guest-account.json**: Updated stale Settings Catalog definition IDs (`com.apple.mcx_com.apple.mcx` renamed to `com.apple.mcx_com.apple.mcx-accounts`, casing changes)
- **pol-sys-105-enrollment-restriction.json**: Fixed `@odata.type`, added `platformType=mac`, removed unsupported `osMinimumVersion`

### mainScript.ps1 enhancements
- Auto-install `Microsoft.Graph.Authentication` module on first run
- New `EnrollmentRestriction` type with full lifecycle support (parse, validate, import, remove, assign)
- New `--enrollment` CLI flag for selective import
- Added `DeviceManagementServiceConfig.ReadWrite.All` Graph scope
- Progress messages during `--remove-all` tenant scanning

### README.md
- Updated permissions list with new scope
- Added `--enrollment` to flags table
- Improved troubleshooting for clean installs

## Testing

Full deployment verified with `--remove-all --apply` followed by `--mde --assign-group "intune-my-macs" --apply` — all 32 items deployed and assigned successfully (exit code 0).
