### PR TITLE
Fix logging path in SCR-APP-101 to match other scripts (#18)

### DIFF
--- a/scripts/intune/scr-app-101-office-defaults.sh
+++ b/scripts/intune/scr-app-101-office-defaults.sh
@@ -42,7 +42,7 @@
 UTILUTI_PATH="/usr/local/bin/utiluti"
 UTILUTI_PKG_URL="https://github.com/scriptingosx/utiluti/releases/download/v1.1/utiluti-1.1.pkg"
 TMP_PKG="/tmp/utiluti.pkg"
-LOGFILE="/Library/Logs/IntuneScripts/setOfficeDefaultApps/setOfficeDefaultApps.log"
+LOGFILE="/Library/Logs/Microsoft/IntuneScripts/setOfficeDefaultApps/setOfficeDefaultApps.log"
 
 WORD_APP="/Applications/Microsoft Word.app"
 EXCEL_APP="/Applications/Microsoft Excel.app"


### PR DESCRIPTION
Resolves #18

Updates SCR-APP-101 (Set Office Default Applications) script to log to 
'/Library/Logs/Microsoft/IntuneScripts/' instead of '/Library/Logs/IntuneScripts/' 
for consistency with all other Intune scripts.