### PR TITLE
Ckunze manifest

### DIFF
--- a/macOS/apps/app-idp-001-psso-autofill.xml
+++ b/macOS/apps/app-idp-001-psso-autofill.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>APP-IDP-001</ReferenceId>
   <Version>1.0</Version>
   <Type>Package</Type>
@@ -16,4 +16,4 @@
     <IgnoreVersionDetection>true</IgnoreVersionDetection>
     <PreInstallScript>apps/Check-PSSO.zsh</PreInstallScript>
   </Package>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/apps/app-sys-001-company-portal.xml
+++ b/macOS/apps/app-sys-001-company-portal.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>APP-SYS-001</ReferenceId>
   <Version>1.0</Version>
   <Type>LobApp</Type>
@@ -16,4 +16,4 @@
     <IgnoreVersionDetection>true</IgnoreVersionDetection>
     <InstallAsManaged>true</InstallAsManaged>
   </Package>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/apps/app-utl-001-swift-dialog.xml
+++ b/macOS/apps/app-utl-001-swift-dialog.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>APP-UTL-001</ReferenceId>
   <Version>1.0</Version>
   <Type>Package</Type>
@@ -15,4 +15,4 @@
     <MinimumSupportedOperatingSystem>v13_0</MinimumSupportedOperatingSystem>
     <IgnoreVersionDetection>true</IgnoreVersionDetection>
   </Package>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/entra/pol-idp-001-platform-sso.xml
+++ b/macOS/configurations/entra/pol-idp-001-platform-sso.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-IDP-001</ReferenceId>
   <Version>1.0</Version>
   <Type>Policy</Type>
@@ -9,4 +9,4 @@
   <SourceFile>configurations/entra/pol-idp-001-platform-sso.json</SourceFile>
     <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>15</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/cfg-sec-001-login-window.xml
+++ b/macOS/configurations/intune/cfg-sec-001-login-window.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>CFG-SEC-001</ReferenceId>
   <Version>1.0</Version>
 	<Type>CustomConfig</Type>
@@ -8,4 +8,4 @@
 	<Category>Security</Category>
 	<SourceFile>configurations/intune/cfg-sec-001-login-window.mobileconfig</SourceFile>
   <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations</CreateGraphUri>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/cfg-sec-002-screensaver-idle.xml
+++ b/macOS/configurations/intune/cfg-sec-002-screensaver-idle.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>CFG-SEC-002</ReferenceId>
   <Version>1.0</Version>
   <Type>CustomConfig</Type>
@@ -8,4 +8,4 @@
   <Category>Security</Category>
   <SourceFile>configurations/intune/cfg-sec-002-screensaver-idle.mobileconfig</SourceFile>
   <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations</CreateGraphUri>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/cfg-sys-100-wallpaper-pppc.xml
+++ b/macOS/configurations/intune/cfg-sys-100-wallpaper-pppc.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>CFG-SYS-100</ReferenceId>
   <Version>1.0</Version>
   <Type>CustomConfig</Type>
@@ -8,4 +8,4 @@
   <Category>Config</Category>
   <SourceFile>configurations/intune/cfg-sys-100-wallpaper-pppc.mobileconfig</SourceFile>
   <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations</CreateGraphUri>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/cmp-cmp-001-macos-baseline.xml
+++ b/macOS/configurations/intune/cmp-cmp-001-macos-baseline.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>CMP-CMP-001</ReferenceId>
   <Version>1.0</Version>
   <Type>Compliance</Type>
@@ -8,4 +8,4 @@
   <Category>Compliance</Category>
   <SourceFile>configurations/intune/cmp-cmp-001-macos-baseline.json</SourceFile>
   <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/deviceCompliancePolicies</CreateGraphUri>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-app-101-company-portal-pppc.xml
+++ b/macOS/configurations/intune/pol-app-101-company-portal-pppc.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-APP-101</ReferenceId>
   <Version>1.0</Version>
   <Type>Policy</Type>
@@ -9,4 +9,4 @@
   <SourceFile>configurations/intune/pol-app-101-company-portal-pppc.json</SourceFile>
     <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sec-001-filevault.xml
+++ b/macOS/configurations/intune/pol-sec-001-filevault.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SEC-001</ReferenceId>
   <Version>1.0</Version>
   <Type>Policy</Type>
@@ -9,4 +9,4 @@
   <SourceFile>configurations/intune/pol-sec-001-filevault.json</SourceFile>
     <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>12</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sec-002-firewall.xml
+++ b/macOS/configurations/intune/pol-sec-002-firewall.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SEC-002</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sec-002-firewall.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>2</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sec-003-gatekeeper.xml
+++ b/macOS/configurations/intune/pol-sec-003-gatekeeper.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SEC-003</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sec-003-gatekeeper.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>2</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sec-004-guest-account.xml
+++ b/macOS/configurations/intune/pol-sec-004-guest-account.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SEC-004</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sec-004-guest-account.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sec-005-screensaver.xml
+++ b/macOS/configurations/intune/pol-sec-005-screensaver.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SEC-005</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sec-005-screensaver.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>2</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sec-006-restrictions.xml
+++ b/macOS/configurations/intune/pol-sec-006-restrictions.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SEC-006</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sec-006-restrictions.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sec-007-recovery-lock.xml
+++ b/macOS/configurations/intune/pol-sec-007-recovery-lock.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SEC-007</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sec-007-recovery-lock.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sys-100-ntp.xml
+++ b/macOS/configurations/intune/pol-sys-100-ntp.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SYS-100</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sys-100-ntp.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sys-101-login-items.xml
+++ b/macOS/configurations/intune/pol-sys-101-login-items.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SYS-101</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sys-101-login-items.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sys-102-power.xml
+++ b/macOS/configurations/intune/pol-sys-102-power.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SYS-102</ReferenceId>
   <Version>1.0</Version>
 	<Type>Policy</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sys-102-power.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sys-103-software-update.xml
+++ b/macOS/configurations/intune/pol-sys-103-software-update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SYS-103</ReferenceId>
   <Version>1.0</Version>
     <Type>Policy</Type>
@@ -10,4 +10,4 @@
     <SourceFile>configurations/intune/pol-sys-103-software-update.json</SourceFile>
       <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>2</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sys-104-ddm-passcode.xml
+++ b/macOS/configurations/intune/pol-sys-104-ddm-passcode.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SYS-104</ReferenceId>
   <Version>1.0</Version>
   <Type>Policy</Type>
@@ -9,4 +9,4 @@
   <SourceFile>configurations/intune/pol-sys-104-ddm-passcode.json</SourceFile>
     <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>12</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sys-105-enrollment-restriction.xml
+++ b/macOS/configurations/intune/pol-sys-105-enrollment-restriction.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SYS-105</ReferenceId>
   <Version>1.0</Version>
 	<Type>EnrollmentRestriction</Type>
@@ -9,4 +9,4 @@
 	<SourceFile>configurations/intune/pol-sys-105-enrollment-restriction.json</SourceFile>
 	  <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/deviceEnrollmentConfigurations</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/intune/pol-sys-106-block-beta.xml
+++ b/macOS/configurations/intune/pol-sys-106-block-beta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-SYS-106</ReferenceId>
   <Version>1.0</Version>
     <Type>Policy</Type>
@@ -10,4 +10,4 @@
     <SourceFile>configurations/intune/pol-sys-106-block-beta.json</SourceFile>
       <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/office/pol-app-100-office.xml
+++ b/macOS/configurations/office/pol-app-100-office.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-APP-100</ReferenceId>
   <Version>2.0</Version>
   <Type>Policy</Type>
@@ -9,4 +9,4 @@
   <SourceFile>configurations/office/pol-app-100-office.json</SourceFile>
     <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>22</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/configurations/office/pol-app-104-onedrive-fda-pppc.xml
+++ b/macOS/configurations/office/pol-app-104-onedrive-fda-pppc.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-APP-104</ReferenceId>
   <Version>1.0</Version>
   <Type>Policy</Type>
@@ -9,4 +9,4 @@
   <SourceFile>configurations/office/pol-app-104-onedrive-fda-pppc.json</SourceFile>
     <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>1</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/custom attributes/cat-sys-100-compatibility-checker.xml
+++ b/macOS/custom attributes/cat-sys-100-compatibility-checker.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>CAT-SYS-100</ReferenceId>
   <Version>1.0</Version>
 	<Type>CustomAttribute</Type>
@@ -11,4 +11,4 @@
 <CustomAttribute>
 		<CustomAttributeType>string</CustomAttributeType>
 	</CustomAttribute>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/custom attributes/cat-sys-101-intune-agent-version.xml
+++ b/macOS/custom attributes/cat-sys-101-intune-agent-version.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>CAT-SYS-101</ReferenceId>
   <Version>1.0</Version>
   <Type>CustomAttribute</Type>
@@ -11,4 +11,4 @@
 <CustomAttribute>
     <CustomAttributeType>string</CustomAttributeType>
   </CustomAttribute>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/custom attributes/cat-sys-102-rosetta-installed.xml
+++ b/macOS/custom attributes/cat-sys-102-rosetta-installed.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>CAT-SYS-102</ReferenceId>
   <Version>1.0</Version>
   <Type>CustomAttribute</Type>
@@ -11,4 +11,4 @@
 <CustomAttribute>
     <CustomAttributeType>string</CustomAttributeType>
   </CustomAttribute>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/mde/pol-mde-001-settings-catalog.xml
+++ b/macOS/mde/pol-mde-001-settings-catalog.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>POL-MDE-001</ReferenceId>
   <Version>1.0</Version>
   <Type>Policy</Type>
@@ -9,4 +9,4 @@
   <SourceFile>mde/pol-mde-001-settings-catalog.json</SourceFile>
     <CreateGraphUri>https://graph.microsoft.com/beta/deviceManagement/configurationPolicies</CreateGraphUri>
 <SettingsCount>0</SettingsCount>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/mde/scr-mde-100-install-defender.xml
+++ b/macOS/mde/scr-mde-100-install-defender.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-MDE-100</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/resources/wallpaper.xml
+++ b/macOS/resources/wallpaper.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>RES-SYS-100</ReferenceId>
   <Version>1.0</Version>
   <Type>Resource</Type>
@@ -7,4 +7,4 @@
   <Platform>macOS</Platform>
   <Category>Config</Category>
   <SourceFile>resources/wallpaper.png</SourceFile>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-100-install-company-portal.xml
+++ b/macOS/scripts/intune/scr-app-100-install-company-portal.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-100</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-101-install-edge.xml
+++ b/macOS/scripts/intune/scr-app-101-install-edge.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-101</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-102-install-remote-help.xml
+++ b/macOS/scripts/intune/scr-app-102-install-remote-help.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-102</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-103-install-intunelogwatch.xml
+++ b/macOS/scripts/intune/scr-app-103-install-intunelogwatch.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-103</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-104-install-M365Apps.xml
+++ b/macOS/scripts/intune/scr-app-104-install-M365Apps.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-104</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-105-install-windows-app.xml
+++ b/macOS/scripts/intune/scr-app-105-install-windows-app.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-105</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-106-install-teams.xml
+++ b/macOS/scripts/intune/scr-app-106-install-teams.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-106</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-app-107-M365copilot.xml
+++ b/macOS/scripts/intune/scr-app-107-M365copilot.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-APP-107</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-sec-100-install-escrow-buddy.xml
+++ b/macOS/scripts/intune/scr-sec-100-install-escrow-buddy.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-SEC-100</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-sys-100-device-rename.xml
+++ b/macOS/scripts/intune/scr-sys-100-device-rename.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-SYS-100</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-sys-101-configure-dock.xml
+++ b/macOS/scripts/intune/scr-sys-101-configure-dock.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-SYS-101</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-sys-102-set-wallpaper.xml
+++ b/macOS/scripts/intune/scr-sys-102-set-wallpaper.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-SYS-102</ReferenceId>
   <Version>1.0</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/macOS/scripts/intune/scr-utl-100-dialog-onboarding.xml
+++ b/macOS/scripts/intune/scr-utl-100-dialog-onboarding.xml
@@ -1,4 +1,4 @@
-<MacIntuneManifest>
+<IntuneManifest>
   <ReferenceId>SCR-UTL-100</ReferenceId>
   <Version>2.1</Version>
   <Type>Script</Type>
@@ -14,4 +14,4 @@
     <ExecutionFrequency>PT0S</ExecutionFrequency>
     <RetryCount>3</RetryCount>
   </Script>
-</MacIntuneManifest>
+</IntuneManifest>

--- a/mainScript.ps1
+++ b/mainScript.ps1
@@ -101,6 +101,8 @@ $applyChanges               = $false # require --apply to move beyond dry-run mo
 # Initialize created object trackers per run
 $createdPolicyIds = @()
 $createdDeviceConfigIds = @()  # classic deviceConfigurations (e.g., macOSCustomConfiguration)
+$createdPolicyDeviceConfigIds = @()  # policy payloads created in deviceConfigurations (e.g., Windows update rings)
+$createdFeatureUpdateProfileIds = @()  # policies created in windowsFeatureUpdateProfiles
 $createdComplianceIds = @()
 $createdScriptIds = @()
 $createdAppIds = @()
@@ -275,7 +277,7 @@ function Get-DistributedManifests {
     $xmlFiles = Get-ChildItem -Path $BasePath -Recurse -Filter *.xml -File -ErrorAction SilentlyContinue | Where-Object {
         try {
             $content = Get-Content -LiteralPath $_.FullName -Raw -ErrorAction Stop
-            $content -match '<MacIntuneManifest'
+            $content -match '<(MacIntuneManifest|IntuneManifest)\b'
         } catch { $false }
     }
     $items = @()
@@ -788,6 +790,8 @@ function Remove-IntunePrefixedContent {
     }
 
     $targetPolicyNames = @{}
+    $targetDeviceConfigPolicyNames = @{}
+    $targetFeatureUpdatePolicyNames = @{}
     $targetComplianceNames = @{}
     $targetCustomConfigNames = @{}
     $targetScriptNames = @{}
@@ -798,7 +802,15 @@ function Remove-IntunePrefixedContent {
     foreach ($m in $platformManifestItems) {
         $displayName = "$Prefix$($m.name)"
         switch ($m.type) {
-            'Policy'               { $targetPolicyNames[$displayName] = $true }
+            'Policy'               {
+                if ($m.createGraphUri -and $m.createGraphUri -match '/deviceConfigurations(\?|$|/)') {
+                    $targetDeviceConfigPolicyNames[$displayName] = $true
+                } elseif ($m.createGraphUri -and $m.createGraphUri -match '/windowsFeatureUpdateProfiles(\?|$|/)') {
+                    $targetFeatureUpdatePolicyNames[$displayName] = $true
+                } else {
+                    $targetPolicyNames[$displayName] = $true
+                }
+            }
             'Compliance'           { $targetComplianceNames[$displayName] = $true }
             'CustomConfig'         { $targetCustomConfigNames[$displayName] = $true }
             'Script'               { $targetScriptNames[$displayName] = $true }
@@ -813,7 +825,7 @@ function Remove-IntunePrefixedContent {
     # Build OData filter string for macOS custom configuration deviceConfiguration lookup
     $escapedFilterDeviceConfigs  = [System.Uri]::EscapeDataString("startsWith(displayName,'$Prefix')")
 
-    $policies = @(); $customConfigs = @(); $compliancePolicies = @(); $enrollmentRestrictions = @(); $scripts = @(); $customAttrs = @(); $apps = @()
+    $policies = @(); $customConfigs = @(); $featureUpdatePolicies = @(); $compliancePolicies = @(); $enrollmentRestrictions = @(); $scripts = @(); $customAttrs = @(); $apps = @()
     
     # Configuration Policies - always use client-side filtering for reliability with special characters
     Write-Host "  Scanning configuration policies..." -ForegroundColor DarkGray -NoNewline
@@ -839,6 +851,27 @@ function Remove-IntunePrefixedContent {
     } catch {
         Write-Host " failed" -ForegroundColor Red
         Write-Warning "Failed to query configuration policies: $($_.Exception.Message)"
+    }
+
+    # Feature update policies live under windowsFeatureUpdateProfiles
+    Write-Host "  Scanning feature update policies..." -ForegroundColor DarkGray -NoNewline
+    try {
+        $allFeatureUpdates = @()
+        $resp = Invoke-MgGraphRequest -Method GET -Uri "https://graph.microsoft.com/beta/deviceManagement/windowsFeatureUpdateProfiles?`$select=id,displayName"
+        if ($resp.value) { $allFeatureUpdates += $resp.value }
+        while ($resp.'@odata.nextLink') {
+            $resp = Invoke-MgGraphRequest -Method GET -Uri $resp.'@odata.nextLink'
+            if ($resp.value) { $allFeatureUpdates += $resp.value }
+        }
+        if ($allFeatureUpdates) {
+            $featureUpdatePolicies = $allFeatureUpdates | Where-Object {
+                $_.displayName -and $_.displayName.StartsWith($Prefix) -and $targetFeatureUpdatePolicyNames.ContainsKey($_.displayName)
+            }
+        }
+        Write-Host " done ($($allFeatureUpdates.Count) found)" -ForegroundColor DarkGray
+    } catch {
+        Write-Host " failed" -ForegroundColor Red
+        Write-Warning "Failed to query feature update policies: $($_.Exception.Message)"
     }
     # Compliance Policies - use client-side filtering with pagination
     Write-Host "  Scanning compliance policies..." -ForegroundColor DarkGray -NoNewline
@@ -873,7 +906,10 @@ function Remove-IntunePrefixedContent {
         }
         if ($raw) {
             $customConfigs = $raw | Where-Object {
-                $_.displayName -and $_.displayName.StartsWith($Prefix) -and $targetCustomConfigNames.ContainsKey($_.displayName)
+                $_.displayName -and $_.displayName.StartsWith($Prefix) -and (
+                    $targetCustomConfigNames.ContainsKey($_.displayName) -or
+                    $targetDeviceConfigPolicyNames.ContainsKey($_.displayName)
+                )
             }
         }
         Write-Host " done" -ForegroundColor DarkGray
@@ -886,7 +922,10 @@ function Remove-IntunePrefixedContent {
             while ($resp.'@odata.nextLink') { $resp = Invoke-MgGraphRequest -Method GET -Uri $resp.'@odata.nextLink'; if ($resp.value) { $raw += $resp.value } }
             if ($raw) {
                 $customConfigs = $raw | Where-Object {
-                    $_.displayName -and $_.displayName.StartsWith($Prefix) -and $targetCustomConfigNames.ContainsKey($_.displayName)
+                    $_.displayName -and $_.displayName.StartsWith($Prefix) -and (
+                        $targetCustomConfigNames.ContainsKey($_.displayName) -or
+                        $targetDeviceConfigPolicyNames.ContainsKey($_.displayName)
+                    )
                 }
             }
         } catch { Write-Warning "Fallback deviceConfigurations query failed: $($_.Exception.Message)" }
@@ -978,12 +1017,13 @@ function Remove-IntunePrefixedContent {
 
     $pCount = ($policies | Measure-Object).Count
     $xCount = ($customConfigs | Measure-Object).Count
+    $fuCount = ($featureUpdatePolicies | Measure-Object).Count
     $cCount = ($compliancePolicies | Measure-Object).Count
     $eCount = ($enrollmentRestrictions | Measure-Object).Count
     $sCount = ($scripts  | Measure-Object).Count
     $caCount = ($customAttrs | Measure-Object).Count
     $aCount = ($apps     | Measure-Object).Count
-    if (($pCount + $xCount + $cCount + $eCount + $sCount + $caCount + $aCount) -eq 0) {
+    if (($pCount + $xCount + $fuCount + $cCount + $eCount + $sCount + $caCount + $aCount) -eq 0) {
         Write-Host "No Intune objects found with prefix '$Prefix'. Nothing to remove." -ForegroundColor Yellow
         return
     }
@@ -996,6 +1036,10 @@ function Remove-IntunePrefixedContent {
     if ($xCount -gt 0) {
         Write-Host "Custom Configs ($xCount):" -ForegroundColor Magenta
         $customConfigs | ForEach-Object { Write-Host "  • $($_.displayName)  [$($_.id)]" }
+    }
+    if ($fuCount -gt 0) {
+        Write-Host "Feature Update Policies ($fuCount):" -ForegroundColor Magenta
+        $featureUpdatePolicies | ForEach-Object { Write-Host "  • $($_.displayName)  [$($_.id)]" }
     }
     if ($cCount -gt 0) {
         Write-Host "Compliance Policies ($cCount):" -ForegroundColor Magenta
@@ -1018,7 +1062,7 @@ function Remove-IntunePrefixedContent {
         $apps | ForEach-Object { Write-Host "  • $($_.displayName)  [$($_.id)]" }
     }
 
-    Write-Host "Summary: $pCount config policies, $xCount custom configs, $cCount compliance policies, $eCount enrollment restrictions, $sCount scripts, $caCount custom attributes, $aCount apps will be permanently removed." -ForegroundColor Cyan
+    Write-Host "Summary: $pCount config policies, $xCount custom configs, $fuCount feature update policies, $cCount compliance policies, $eCount enrollment restrictions, $sCount scripts, $caCount custom attributes, $aCount apps will be permanently removed." -ForegroundColor Cyan
 
     if (-not $ApplyChanges) {
         Write-Host "[dry-run] Skipping deletion because --apply was not provided." -ForegroundColor Yellow
@@ -1045,6 +1089,13 @@ function Remove-IntunePrefixedContent {
             Invoke-MgGraphRequest -Method DELETE -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations/$($cc.id)" | Out-Null
             Write-Host "Deleted custom config: $($cc.displayName)" -ForegroundColor Green
         } catch { Write-Warning "Failed to delete custom config $($cc.displayName): $($_.Exception.Message)" }
+    }
+    # Delete feature update policies
+    foreach ($fu in $featureUpdatePolicies) {
+        try {
+            Invoke-MgGraphRequest -Method DELETE -Uri "https://graph.microsoft.com/beta/deviceManagement/windowsFeatureUpdateProfiles/$($fu.id)" | Out-Null
+            Write-Host "Deleted feature update policy: $($fu.displayName)" -ForegroundColor Green
+        } catch { Write-Warning "Failed to delete feature update policy $($fu.displayName): $($_.Exception.Message)" }
     }
     # Delete compliance policies
     foreach ($cp in $compliancePolicies) {
@@ -1881,6 +1932,8 @@ function Remove-SettingsWithReusableReferenceIds {
 # Enumerate policies
 if ($importPolicies) {
     $createdPolicyIds = @()
+    $createdPolicyDeviceConfigIds = @()
+    $createdFeatureUpdateProfileIds = @()
     $policies = $distributedItems | Where-Object { $_.type -eq 'Policy' }
 
     Write-Host "Found $($policies.Count) policies:`n" -ForegroundColor Cyan
@@ -1902,11 +1955,22 @@ if ($importPolicies) {
         try {
             $policyContentJson = Get-Content -LiteralPath $policyPath -Raw
             $policyContent = ConvertFrom-Json -InputObject $policyContentJson -Depth 20
-                # Override JSON name with XML manifest <Name> to keep single source of truth
-                if ($policyPrefix) {
-                    $policyContent.name = $policyPrefix + $p.name
+                # Override payload display name with XML manifest <Name> to keep a single source of truth.
+                $resolvedPolicyName = if ($policyPrefix) { $policyPrefix + $p.name } else { $p.name }
+                if ($policyContent.PSObject.Properties.Name -contains 'name') {
+                    $policyContent.name = $resolvedPolicyName
+                } elseif ($policyContent.PSObject.Properties.Name -contains 'displayName') {
+                    $policyContent.displayName = $resolvedPolicyName
                 } else {
-                    $policyContent.name = $p.name
+                    $policyContent | Add-Member -NotePropertyName displayName -NotePropertyValue $resolvedPolicyName -Force
+                }
+
+                $policyDisplayName = if ($policyContent.PSObject.Properties.Name -contains 'name') {
+                    $policyContent.name
+                } elseif ($policyContent.PSObject.Properties.Name -contains 'displayName') {
+                    $policyContent.displayName
+                } else {
+                    $resolvedPolicyName
                 }
 
                 $policyContentJson = ConvertTo-Json -InputObject $policyContent -Depth 20
@@ -1927,7 +1991,7 @@ if ($importPolicies) {
                 }
 
             if (-not $applyChanges) {
-                Write-Host "  - [dry-run] Would create configuration policy '$($policyContent.name)'." -ForegroundColor DarkGray
+                Write-Host "  - [dry-run] Would create configuration policy '$policyDisplayName'." -ForegroundColor DarkGray
             } else {
                 # create policy with json content
                 $policyImportResults = $null
@@ -1959,9 +2023,26 @@ if ($importPolicies) {
                 }
 
                 if ($policyImportResults) {
-                    Write-Host "  - Policy $($policyImportResults.name) imported successfully with ID: $($policyImportResults.id)" -ForegroundColor Green
-                    $createdPolicyIds += $policyImportResults.id
-                    Add-CreatedObject -Platform $p.platform -Type 'Policy' -Name $policyImportResults.name -Id $policyImportResults.id
+                    $resultName = if ($policyImportResults.PSObject.Properties.Name -contains 'name') {
+                        $policyImportResults.name
+                    } elseif ($policyImportResults.PSObject.Properties.Name -contains 'displayName') {
+                        $policyImportResults.displayName
+                    } else {
+                        $policyDisplayName
+                    }
+                    Write-Host "  - Policy $resultName imported successfully with ID: $($policyImportResults.id)" -ForegroundColor Green
+                    if ($p.createGraphUri -and $p.createGraphUri -match '/deviceConfigurations(\?|$|/)') {
+                        # Some Windows policy payloads (for example update rings) are created in deviceConfigurations
+                        # and must be assigned through the deviceConfigurations assignment endpoint.
+                        $createdDeviceConfigIds += $policyImportResults.id
+                        $createdPolicyDeviceConfigIds += $policyImportResults.id
+                    } elseif ($p.createGraphUri -and $p.createGraphUri -match '/windowsFeatureUpdateProfiles(\?|$|/)') {
+                        # Windows feature update profiles are created and assigned via windowsFeatureUpdateProfiles.
+                        $createdFeatureUpdateProfileIds += $policyImportResults.id
+                    } else {
+                        $createdPolicyIds += $policyImportResults.id
+                    }
+                    Add-CreatedObject -Platform $p.platform -Type 'Policy' -Name $resultName -Id $policyImportResults.id
                 } else {
                     Write-Host "  - Policy import failed or returned no results." -ForegroundColor Red
                 }
@@ -2229,9 +2310,18 @@ if ($importPackages) {
                         if ($pkgVersion) {
                             $pkgVersion = $pkgVersion.Trim()
                             [xml]$manifestXml = Get-Content $cpManifestPath -Raw
-                            $manifestXml.MacIntuneManifest.Package.PrimaryBundleVersion = $pkgVersion
-                            $manifestXml.Save($cpManifestPath)
-                            Write-Host "  Updated PrimaryBundleVersion to $pkgVersion" -ForegroundColor Green
+                            $manifestRoot = $manifestXml.DocumentElement
+                            if ($manifestRoot -and $manifestRoot.Name -in @('MacIntuneManifest','IntuneManifest')) {
+                                $packageNode = $manifestRoot.SelectSingleNode('Package')
+                                if ($packageNode) {
+                                    $bundleVersionNode = $packageNode.SelectSingleNode('PrimaryBundleVersion')
+                                    if ($bundleVersionNode) {
+                                        $bundleVersionNode.InnerText = $pkgVersion
+                                        $manifestXml.Save($cpManifestPath)
+                                        Write-Host "  Updated PrimaryBundleVersion to $pkgVersion" -ForegroundColor Green
+                                    }
+                                }
+                            }
                         }
                     }
                 } finally {
@@ -2429,8 +2519,29 @@ if ($assignGroupName) {
         try {
             $assignBody = @{ assignments = @(@{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $groupId } }) } | ConvertTo-Json -Depth 6
             Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceManagement/deviceConfigurations/$devCfgId/assign" -Body $assignBody | Out-Null
-            Write-Host "Assigned custom config $devCfgId to group" -ForegroundColor Green
-        } catch { Write-Warning "Failed to assign custom config ${devCfgId}: $($_.Exception.Message)" }
+            if ($createdPolicyDeviceConfigIds -contains $devCfgId) {
+                Write-Host "Assigned policy $devCfgId to group" -ForegroundColor Green
+            } else {
+                Write-Host "Assigned custom config $devCfgId to group" -ForegroundColor Green
+            }
+        } catch {
+            if ($createdPolicyDeviceConfigIds -contains $devCfgId) {
+                Write-Warning "Failed to assign policy ${devCfgId}: $($_.Exception.Message)"
+            } else {
+                Write-Warning "Failed to assign custom config ${devCfgId}: $($_.Exception.Message)"
+            }
+        }
+    }
+
+    # Assign feature update policies (windowsFeatureUpdateProfiles)
+    foreach ($fuId in ($createdFeatureUpdateProfileIds | Sort-Object -Unique)) {
+        try {
+            $assignBody = @{ assignments = @(@{ target = @{ '@odata.type' = '#microsoft.graph.groupAssignmentTarget'; groupId = $groupId } }) } | ConvertTo-Json -Depth 6
+            Invoke-MgGraphRequest -Method POST -Uri "https://graph.microsoft.com/beta/deviceManagement/windowsFeatureUpdateProfiles/$fuId/assign" -Body $assignBody | Out-Null
+            Write-Host "Assigned policy $fuId to group" -ForegroundColor Green
+        } catch {
+            Write-Warning "Failed to assign policy ${fuId}: $($_.Exception.Message)"
+        }
     }
 
     # Assign Compliance Policies (deviceCompliancePolicies)

--- a/tools/Get-MacOSGlobalAssignments.md
+++ b/tools/Get-MacOSGlobalAssignments.md
@@ -24,6 +24,20 @@ The script flags objects assigned to:
 - **All Devices** (`allDevicesAssignmentTarget`) - Applies to every device in the tenant
 - **All Users** (`allLicensedUsersAssignmentTarget`) - Applies to all licensed users
 
+For each global assignment it also reports whether an **assignment filter** is
+applied, resolving the filter's GUID to its display name and showing the mode
+(`include` or `exclude`). Rows with **no filter** on their global assignment are
+highlighted in **red** in the console table to call out the broadest, unscoped
+targeting.
+
+### Performance
+
+All list queries (assignment filters plus the six object categories) are
+retrieved in a **single Microsoft Graph `$batch` request** with
+`$expand=assignments`, so assignments come back inline. This collapses what
+used to be many sequential round trips into one, with additional pages fetched
+only when a category exceeds the page size.
+
 ## Requirements
 
 - **PowerShell 7+** (cross-platform) or Windows PowerShell 5.1
@@ -44,23 +58,21 @@ pwsh ./tools/Get-MacOSGlobalAssignments.ps1
 Output:
 
 ```text
-Collecting configurationPolicies (settings catalog macOS)...
-Collecting classic deviceConfigurations (macOS types)...
-Collecting deviceCompliancePolicies (macOS)...
-Collecting deviceShellScripts (macOS shell scripts)...
-Collecting deviceCustomAttributeShellScripts (macOS)...
-Collecting macOS mobileApps (all macOS app types)...
+Collecting macOS objects (single batched request)...
 
-Type                  Name                           Id              AllDevices AllUsers Intent   Platforms
-----                  ----                           --              ---------- -------- ------   ---------
-CompliancePolicy      macOS Baseline Compliance      a1b2...                True    False          macOS
-CustomAttribute       Rosetta Installed              c3d4...                True    False          macOS
-DeviceConfiguration   FileVault Policy               abc1...                True    False          macOS
-SettingsCatalogPolicy macOS Security Baseline        def6...                True     True          macOS
-ShellScript           Rosetta Check First Run Script 0b6c...                True    False          macOS
-macOSApp              Company Portal                 jkl2...               False     True available macOS
+Type                  Name                           Id              AllDevices AllUsers Filter            Intent   Platforms
+----                  ----                           --              ---------- -------- ------            ------   ---------
+CompliancePolicy      macOS Baseline Compliance      a1b2...                True    False                          macOS
+CustomAttribute       Rosetta Installed              c3d4...                True    False Corporate (include)       macOS
+DeviceConfiguration   FileVault Policy               abc1...                True    False                          macOS
+SettingsCatalogPolicy macOS Security Baseline        def6...                True     True Corporate (include)       macOS
+ShellScript           Rosetta Check First Run Script 0b6c...                True    False                          macOS
+macOSApp              Company Portal                 jkl2...               False     True                 available macOS
 macOSApp              Microsoft Defender             m3n4...                True    False required macOS
 ```
+
+> Rows with an empty `Filter` (global assignment with no assignment filter) are
+> printed in **red** to highlight unscoped targeting.
 
 ### Parameters
 
@@ -118,6 +130,7 @@ pwsh ./tools/Get-MacOSGlobalAssignments.ps1 -Unassign -Force
 | `Id` | Intune object GUID |
 | `AllDevices` | `True` if assigned to All Devices |
 | `AllUsers` | `True` if assigned to All Users |
+| `Filter` | Assignment filter(s) applied to the global assignment, shown as `FilterName (include\|exclude)`. Empty when no filter is applied — these rows are highlighted in **red**. |
 | `Intent` | App install intent for the global assignment(s): `required`, `available`, `availableWithoutEnrollment`, `uninstall`, or a comma-separated combination. Empty for non-app rows. |
 | `Platforms` | Platform(s) the object targets |
 
@@ -135,6 +148,7 @@ Same columns as console output, suitable for Excel or reporting tools.
     "Id": "abc12345-6789-0123-4567-890abcdef012",
     "AllDevices": true,
     "AllUsers": false,
+    "Filter": "",
     "Intent": "",
     "Platforms": "macOS"
   },
@@ -144,6 +158,7 @@ Same columns as console output, suitable for Excel or reporting tools.
     "Id": "m3n4o5p6-...",
     "AllDevices": true,
     "AllUsers": false,
+    "Filter": "Corporate (include)",
     "Intent": "required",
     "Platforms": "macOS"
   }
@@ -277,6 +292,8 @@ if ($results) {
 ## Notes
 
 - Uses Microsoft Graph **beta** endpoint for full macOS support
+- All categories are fetched in a single Graph `$batch` request using `$expand=assignments`; additional pages are pulled only when a category exceeds the page size (so tenants with more than 100 objects in a category are still fully covered)
+- Assignment filter GUIDs are resolved to display names via the `deviceManagement/assignmentFilters` list (retrieved in the same batch)
 - Shell scripts (`deviceShellScripts`) and custom attribute shell scripts (`deviceCustomAttributeShellScripts`) are macOS-only endpoints; no platform filter is needed for those
-- For shell scripts and custom attributes, assignments are fetched via `$expand=assignments` on the list endpoint because the per-object `/assignments` sub-endpoint returns HTTP 400 on some tenants
+- For shell scripts and custom attributes, assignments come from `$expand=assignments` on the list endpoint because the per-object `/assignments` sub-endpoint returns HTTP 400 on some tenants
 - The script only surfaces macOS objects, even though some APIs return cross-platform data

--- a/tools/Get-MacOSGlobalAssignments.ps1
+++ b/tools/Get-MacOSGlobalAssignments.ps1
@@ -13,6 +13,8 @@ Queries Microsoft Graph (beta) for:
 For each object, retrieves its assignments and flags whether it is targeted to:
   - All Devices (allDevicesAssignmentTarget)
   - All Users (allLicensedUsersAssignmentTarget)
+For any such global assignment it also reports whether an assignment filter is
+applied (filter display name and include/exclude mode).
 Outputs a table and (optionally) JSON/CSV.
 
 .PARAMETER OutputJson
@@ -60,32 +62,77 @@ function Ensure-GraphConnection {
     }
 }
 
-function Invoke-GraphAllPages {
+function Get-GraphBatchResults {
+    # Submits multiple GET list requests in a single Graph $batch round trip,
+    # then drains any per-request nextLink pages (rare for small tenants).
+    # $Requests: ordered/hashtable of id => version-relative URL (leading '/').
     param(
-        [Parameter(Mandatory)] [string]$Uri,
-        [hashtable]$Headers,
-        [int]$PageSize = 100
+        [Parameter(Mandatory)] $Requests
     )
-    $results = @()
-    $next = "$Uri`?`$top=$PageSize"
-    while ($next) {
-        $resp = Invoke-MgGraphRequest -Method GET -Uri $next -Headers $Headers
-        if ($resp.value) { $results += $resp.value }
-        $next = $resp.'@odata.nextLink'
+    $base = 'https://graph.microsoft.com/beta'
+    $reqList = foreach ($id in $Requests.Keys) {
+        @{ id = [string]$id; method = 'GET'; url = $Requests[$id] }
     }
-    return $results
+    $body = @{ requests = @($reqList) } | ConvertTo-Json -Depth 5
+    $resp = Invoke-MgGraphRequest -Method POST -Uri "$base/`$batch" -Body $body -ContentType 'application/json'
+
+    $out = @{}
+    foreach ($r in $resp.responses) {
+        $items = [System.Collections.Generic.List[object]]::new()
+        if ($r.status -ge 200 -and $r.status -lt 300 -and $r.body) {
+            if ($r.body.value) { $items.AddRange([object[]]$r.body.value) }
+            $next = $r.body.'@odata.nextLink'
+            while ($next) {
+                $page = Invoke-MgGraphRequest -Method GET -Uri $next
+                if ($page.value) { $items.AddRange([object[]]$page.value) }
+                $next = $page.'@odata.nextLink'
+            }
+        } elseif ($r.status -ge 400) {
+            Write-Warning "Batch request '$($r.id)' failed (HTTP $($r.status)); results for that category may be incomplete."
+        }
+        $out[$r.id] = $items
+    }
+    return $out
 }
 
-function Get-AssignmentsForObject {
+function Get-FilterDisplay {
     param(
-        [string]$Uri # full assignments URI
+        $Target,
+        [hashtable]$FilterLookup
     )
-    try {
-        $resp = Invoke-MgGraphRequest -Method GET -Uri $Uri
-        return $resp.value
-    } catch {
-        Write-Warning "Failed to query assignments: $Uri : $($_.Exception.Message)"
-        return @()
+    $fid   = $Target.deviceAndAppManagementAssignmentFilterId
+    $ftype = $Target.deviceAndAppManagementAssignmentFilterType
+    if (-not $fid -or $fid -eq '00000000-0000-0000-0000-000000000000' -or -not $ftype -or $ftype -eq 'none') {
+        return $null
+    }
+    $name = if ($FilterLookup.ContainsKey($fid)) { $FilterLookup[$fid] } else { $fid }
+    return "$name ($ftype)"
+}
+
+function Get-GlobalAssignmentInfo {
+    param(
+        $Assignments,
+        [hashtable]$FilterLookup
+    )
+    $isAllDevices = $false; $isAllUsers = $false
+    $filters = New-Object System.Collections.Generic.HashSet[string]
+    $intents = New-Object System.Collections.Generic.HashSet[string]
+    foreach ($a in $Assignments) {
+        $t = $a.target.'@odata.type'
+        $isGlobal = $false
+        if ($t -eq '#microsoft.graph.allDevicesAssignmentTarget') { $isAllDevices = $true; $isGlobal = $true }
+        if ($t -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') { $isAllUsers = $true; $isGlobal = $true }
+        if ($isGlobal) {
+            $f = Get-FilterDisplay -Target $a.target -FilterLookup $FilterLookup
+            if ($f) { [void]$filters.Add($f) }
+            if ($a.intent) { [void]$intents.Add([string]$a.intent) }
+        }
+    }
+    return [pscustomobject]@{
+        AllDevices = $isAllDevices
+        AllUsers   = $isAllUsers
+        Filter     = (($filters | Sort-Object) -join '; ')
+        Intent     = (($intents | Sort-Object) -join ',')
     }
 }
 
@@ -93,52 +140,40 @@ Ensure-GraphConnection
 
 $betaBase = 'https://graph.microsoft.com/beta'
 
-Write-Host 'Collecting configurationPolicies (settings catalog macOS)...' -ForegroundColor Cyan
-$configPolicies = Invoke-GraphAllPages -Uri "$betaBase/deviceManagement/configurationPolicies" | Where-Object { $_.platforms -match 'macOS' }
+Write-Host 'Collecting macOS objects (single batched request)...' -ForegroundColor Cyan
+$batch = Get-GraphBatchResults -Requests ([ordered]@{
+    filters    = '/deviceManagement/assignmentFilters?$top=100'
+    config     = '/deviceManagement/configurationPolicies?$top=100&$expand=assignments'
+    devcfg     = '/deviceManagement/deviceConfigurations?$top=100&$expand=assignments'
+    compliance = '/deviceManagement/deviceCompliancePolicies?$top=100&$expand=assignments'
+    shell      = '/deviceManagement/deviceShellScripts?$top=100&$expand=assignments'
+    customattr = '/deviceManagement/deviceCustomAttributeShellScripts?$top=100&$expand=assignments'
+    apps       = '/deviceAppManagement/mobileApps?$top=100&$expand=assignments'
+})
 
-Write-Host 'Collecting classic deviceConfigurations (macOS types)...' -ForegroundColor Cyan
-$deviceConfigs = Invoke-GraphAllPages -Uri "$betaBase/deviceManagement/deviceConfigurations" | Where-Object { $_.'@odata.type' -like '#microsoft.graph.macOS*' }
+$filterLookup = @{}
+foreach ($f in $batch['filters']) { if ($f.id) { $filterLookup[$f.id] = $f.displayName } }
 
-Write-Host 'Collecting deviceCompliancePolicies (macOS)...' -ForegroundColor Cyan
-$compliancePolicies = Invoke-GraphAllPages -Uri "$betaBase/deviceManagement/deviceCompliancePolicies" | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.macOSCompliancePolicy' }
-
-Write-Host 'Collecting deviceShellScripts (macOS shell scripts)...' -ForegroundColor Cyan
-# /assignments sub-endpoint 400s on some tenants — prefer $expand=assignments on the list.
-try {
-    $shellScriptsResponse = Invoke-MgGraphRequest -Method GET -Uri "$betaBase/deviceManagement/deviceShellScripts?`$top=999&`$expand=assignments"
-    $deviceShellScripts = $shellScriptsResponse.value
-} catch {
-    Write-Warning "Failed expanded retrieval of deviceShellScripts: $($_.Exception.Message). Falling back to basic list (assignments may be incomplete)."
-    $deviceShellScripts = Invoke-GraphAllPages -Uri "$betaBase/deviceManagement/deviceShellScripts"
-}
-
-Write-Host 'Collecting deviceCustomAttributeShellScripts (macOS)...' -ForegroundColor Cyan
-# Same /assignments quirk as deviceShellScripts — use $expand.
-try {
-    $customAttrResponse = Invoke-MgGraphRequest -Method GET -Uri "$betaBase/deviceManagement/deviceCustomAttributeShellScripts?`$top=999&`$expand=assignments"
-    $customAttrScripts = $customAttrResponse.value
-} catch {
-    Write-Warning "Failed expanded retrieval of deviceCustomAttributeShellScripts: $($_.Exception.Message). Falling back to basic list (assignments may be incomplete)."
-    $customAttrScripts = Invoke-GraphAllPages -Uri "$betaBase/deviceManagement/deviceCustomAttributeShellScripts"
-}
-
-Write-Host 'Collecting macOS mobileApps (all macOS app types)...' -ForegroundColor Cyan
-$mobileApps = Invoke-GraphAllPages -Uri "$betaBase/deviceAppManagement/mobileApps" | Where-Object { $_.'@odata.type' -like '#microsoft.graph.macOS*' }
+$configPolicies     = $batch['config']     | Where-Object { $_.platforms -match 'macOS' }
+$deviceConfigs      = $batch['devcfg']     | Where-Object { $_.'@odata.type' -like '#microsoft.graph.macOS*' }
+$compliancePolicies = $batch['compliance'] | Where-Object { $_.'@odata.type' -eq '#microsoft.graph.macOSCompliancePolicy' }
+$deviceShellScripts = $batch['shell']
+$customAttrScripts  = $batch['customattr']
+$mobileApps         = $batch['apps']       | Where-Object { $_.'@odata.type' -like '#microsoft.graph.macOS*' }
 
 $rows = @()
 
 # Settings catalog policies assignments
 foreach ($p in $configPolicies) {
-    $assignments = Get-AssignmentsForObject -Uri "$betaBase/deviceManagement/configurationPolicies/$($p.id)/assignments"
-    $isAllDevices = $assignments.target.'@odata.type' -contains '#microsoft.graph.allDevicesAssignmentTarget'
-    $isAllUsers   = $assignments.target.'@odata.type' -contains '#microsoft.graph.allLicensedUsersAssignmentTarget'
-    if ($isAllDevices -or $isAllUsers) {
+    $info = Get-GlobalAssignmentInfo -Assignments $p.assignments -FilterLookup $filterLookup
+    if ($info.AllDevices -or $info.AllUsers) {
         $rows += [pscustomobject]@{
             Type        = 'SettingsCatalogPolicy'
             Name        = $p.name
             Id          = $p.id
-            AllDevices  = $isAllDevices
-            AllUsers    = $isAllUsers
+            AllDevices  = $info.AllDevices
+            AllUsers    = $info.AllUsers
+            Filter      = $info.Filter
             Intent      = ''
             Platforms   = ($p.platforms -join ',')
         }
@@ -147,20 +182,15 @@ foreach ($p in $configPolicies) {
 
 # Classic / custom device configurations
 foreach ($c in $deviceConfigs) {
-    $assignments = Get-AssignmentsForObject -Uri "$betaBase/deviceManagement/deviceConfigurations/$($c.id)/assignments"
-    $isAllDevices = $false; $isAllUsers = $false
-    foreach ($a in $assignments) {
-        $t = $a.target.'@odata.type'
-        if ($t -eq '#microsoft.graph.allDevicesAssignmentTarget') { $isAllDevices = $true }
-        if ($t -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') { $isAllUsers = $true }
-    }
-    if ($isAllDevices -or $isAllUsers) {
+    $info = Get-GlobalAssignmentInfo -Assignments $c.assignments -FilterLookup $filterLookup
+    if ($info.AllDevices -or $info.AllUsers) {
         $rows += [pscustomobject]@{
             Type       = 'DeviceConfiguration'
             Name       = $c.displayName
             Id         = $c.id
-            AllDevices = $isAllDevices
-            AllUsers   = $isAllUsers
+            AllDevices = $info.AllDevices
+            AllUsers   = $info.AllUsers
+            Filter     = $info.Filter
             Intent     = ''
             Platforms  = 'macOS'
         }
@@ -169,20 +199,15 @@ foreach ($c in $deviceConfigs) {
 
 # Compliance policies
 foreach ($cp in $compliancePolicies) {
-    $assignments = Get-AssignmentsForObject -Uri "$betaBase/deviceManagement/deviceCompliancePolicies/$($cp.id)/assignments"
-    $isAllDevices = $false; $isAllUsers = $false
-    foreach ($a in $assignments) {
-        $t = $a.target.'@odata.type'
-        if ($t -eq '#microsoft.graph.allDevicesAssignmentTarget') { $isAllDevices = $true }
-        if ($t -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') { $isAllUsers = $true }
-    }
-    if ($isAllDevices -or $isAllUsers) {
+    $info = Get-GlobalAssignmentInfo -Assignments $cp.assignments -FilterLookup $filterLookup
+    if ($info.AllDevices -or $info.AllUsers) {
         $rows += [pscustomobject]@{
             Type       = 'CompliancePolicy'
             Name       = $cp.displayName
             Id         = $cp.id
-            AllDevices = $isAllDevices
-            AllUsers   = $isAllUsers
+            AllDevices = $info.AllDevices
+            AllUsers   = $info.AllUsers
+            Filter     = $info.Filter
             Intent     = ''
             Platforms  = 'macOS'
         }
@@ -197,19 +222,15 @@ foreach ($s in $deviceShellScripts) {
         try { (Invoke-MgGraphRequest -Method GET -Uri "$betaBase/deviceManagement/deviceShellScripts/$($s.id)/assignments").value }
         catch { @() }
     }
-    $isAllDevices = $false; $isAllUsers = $false
-    foreach ($a in $expandedAssignments) {
-        $t = $a.target.'@odata.type'
-        if ($t -eq '#microsoft.graph.allDevicesAssignmentTarget') { $isAllDevices = $true }
-        if ($t -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') { $isAllUsers = $true }
-    }
-    if ($isAllDevices -or $isAllUsers) {
+    $info = Get-GlobalAssignmentInfo -Assignments $expandedAssignments -FilterLookup $filterLookup
+    if ($info.AllDevices -or $info.AllUsers) {
         $rows += [pscustomobject]@{
             Type       = 'ShellScript'
             Name       = $s.displayName
             Id         = $s.id
-            AllDevices = $isAllDevices
-            AllUsers   = $isAllUsers
+            AllDevices = $info.AllDevices
+            AllUsers   = $info.AllUsers
+            Filter     = $info.Filter
             Intent     = ''
             Platforms  = 'macOS'
         }
@@ -222,19 +243,15 @@ foreach ($ca in $customAttrScripts) {
         try { (Invoke-MgGraphRequest -Method GET -Uri "$betaBase/deviceManagement/deviceCustomAttributeShellScripts/$($ca.id)/assignments").value }
         catch { @() }
     }
-    $isAllDevices = $false; $isAllUsers = $false
-    foreach ($a in $expandedAssignments) {
-        $t = $a.target.'@odata.type'
-        if ($t -eq '#microsoft.graph.allDevicesAssignmentTarget') { $isAllDevices = $true }
-        if ($t -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') { $isAllUsers = $true }
-    }
-    if ($isAllDevices -or $isAllUsers) {
+    $info = Get-GlobalAssignmentInfo -Assignments $expandedAssignments -FilterLookup $filterLookup
+    if ($info.AllDevices -or $info.AllUsers) {
         $rows += [pscustomobject]@{
             Type       = 'CustomAttribute'
             Name       = $ca.displayName
             Id         = $ca.id
-            AllDevices = $isAllDevices
-            AllUsers   = $isAllUsers
+            AllDevices = $info.AllDevices
+            AllUsers   = $info.AllUsers
+            Filter     = $info.Filter
             Intent     = ''
             Platforms  = 'macOS'
         }
@@ -243,28 +260,16 @@ foreach ($ca in $customAttrScripts) {
 
 # macOS Apps
 foreach ($app in $mobileApps) {
-    $assignments = Get-AssignmentsForObject -Uri "$betaBase/deviceAppManagement/mobileApps/$($app.id)/assignments"
-    $isAllDevices = $false; $isAllUsers = $false
-    $intents = New-Object System.Collections.Generic.HashSet[string]
-    foreach ($a in $assignments) {
-        $t = $a.target.'@odata.type'
-        if ($t -eq '#microsoft.graph.allDevicesAssignmentTarget') {
-            $isAllDevices = $true
-            if ($a.intent) { [void]$intents.Add([string]$a.intent) }
-        }
-        if ($t -eq '#microsoft.graph.allLicensedUsersAssignmentTarget') {
-            $isAllUsers = $true
-            if ($a.intent) { [void]$intents.Add([string]$a.intent) }
-        }
-    }
-    if ($isAllDevices -or $isAllUsers) {
+    $info = Get-GlobalAssignmentInfo -Assignments $app.assignments -FilterLookup $filterLookup
+    if ($info.AllDevices -or $info.AllUsers) {
         $rows += [pscustomobject]@{
             Type       = 'macOSApp'
             Name       = $app.displayName
             Id         = $app.id
-            AllDevices = $isAllDevices
-            AllUsers   = $isAllUsers
-            Intent     = (($intents | Sort-Object) -join ',')
+            AllDevices = $info.AllDevices
+            AllUsers   = $info.AllUsers
+            Filter     = $info.Filter
+            Intent     = $info.Intent
             Platforms  = 'macOS'
         }
     }
@@ -275,7 +280,24 @@ if (-not $rows) {
     return
 }
 
-$rows | Sort-Object Type, Name | Format-Table -AutoSize
+# Highlight global assignments that have NO assignment filter applied (red).
+# Format-Table is ANSI-aware in PowerShell 7.2+, so wrapping each cell value
+# keeps column widths correct.
+$esc = [char]27
+$red = "$esc[31m"
+$reset = "$esc[0m"
+$display = $rows | Sort-Object Type, Name | ForEach-Object {
+    if ([string]::IsNullOrWhiteSpace($_.Filter)) {
+        $colored = [ordered]@{}
+        foreach ($prop in $_.PSObject.Properties) {
+            $colored[$prop.Name] = "$red$($prop.Value)$reset"
+        }
+        [pscustomobject]$colored
+    } else {
+        $_
+    }
+}
+$display | Format-Table -AutoSize
 
 if ($CsvPath) {
     try {

--- a/tools/Get-MacOSGlobalAssignments.ps1
+++ b/tools/Get-MacOSGlobalAssignments.ps1
@@ -34,7 +34,7 @@ Requires Microsoft.Graph.Authentication (Connect-MgGraph) and sufficient Intune 
 #>
 
 # Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+
 
 param(
     [switch]$OutputJson,


### PR DESCRIPTION
<!-- Copyright (c) Microsoft Corporation. -->
<!-- Licensed under the MIT License. -->

## Summary

<!-- What does this change do, and why? Link any related issue (#123). -->

## Type of change

- [ ] New or changed Intune artifact (policy / config / script / app / custom attribute)
- [ ] Engine or tooling change (`mainScript.ps1`, `Start-IntuneMyMacs.ps1`, `tools/`)
- [ ] Documentation / agent context
- [ ] Other (describe):

## Validation

- [ ] `./tools/verify.sh` passes.
- [ ] Any new/changed artifact has a sibling `.xml` manifest with a **unique** `<ReferenceId>` and a `<SourceFile>` that resolves.
- [ ] Settings Catalog `settings[]` IDs are contiguous and 0-based.
- [ ] Dry-ran `mainScript.ps1` and the result looks correct (`pwsh ./mainScript.ps1 …`, no `--apply`).
- [ ] Regenerated `INTUNE-MY-MACS-DOCUMENTATION.md` if artifacts changed (`python3 tools/Generate-ConfigurationDocumentation.py`).
- [ ] Added the Microsoft copyright header to new first-party files; preserved any third-party notice.
- [ ] Updated `CHANGELOG.md` (newest first), linking changed file paths.

## Notes

<!-- Anything reviewers should know: trade-offs, follow-ups, screenshots. -->
